### PR TITLE
Add useradd(1) arg to force user group creation

### DIFF
--- a/import_users.sh
+++ b/import_users.sh
@@ -42,7 +42,7 @@ fi
 : ${USERADD_PROGRAM:="/usr/sbin/useradd"}
 
 # Possibility to provide custom useradd arguments
-: ${USERADD_ARGS:="--create-home --shell /bin/bash"}
+: ${USERADD_ARGS:="--user-group --create-home --shell /bin/bash"}
 
 # Initizalize INSTANCE variable
 INSTANCE_ID=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)


### PR DESCRIPTION
By default on most distros, `USERGROUPS_ENAB` is set to `yes` which
causes `useradd(1)` to create a group for a user that is added.

There is an implicit dependency on line 179 of the `import_users.sh`
script. I've altered the `useradd(1)` argument set to include
`-U/--user-group` to force this on systems where `USERGROUPS_ENAB`
is set to `no`