### PR TITLE
sshd_config duplicate lines

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -124,13 +124,17 @@ fi
 if grep -q '#AuthorizedKeysCommand none' $SSHD_CONFIG_FILE; then
     sed -i "s:#AuthorizedKeysCommand none:AuthorizedKeysCommand ${AUTHORIZED_KEYS_COMMAND_FILE}:g" $SSHD_CONFIG_FILE
 else
-    echo "AuthorizedKeysCommand ${AUTHORIZED_KEYS_COMMAND_FILE}" >> $SSHD_CONFIG_FILE
+    if ! grep -q "AuthorizedKeysCommand ${AUTHORIZED_KEYS_COMMAND_FILE}" $SSHD_CONFIG_FILE; then
+        echo "AuthorizedKeysCommand ${AUTHORIZED_KEYS_COMMAND_FILE}" >> $SSHD_CONFIG_FILE
+    fi
 fi
 
 if grep -q '#AuthorizedKeysCommandUser nobody' $SSHD_CONFIG_FILE; then
     sed -i "s:#AuthorizedKeysCommandUser nobody:AuthorizedKeysCommandUser nobody:g" $SSHD_CONFIG_FILE
 else
-    echo "AuthorizedKeysCommandUser nobody" >> $SSHD_CONFIG_FILE
+    if ! grep -q 'AuthorizedKeysCommandUser nobody' $SSHD_CONFIG_FILE; then
+        echo "AuthorizedKeysCommandUser nobody" >> $SSHD_CONFIG_FILE
+    fi
 fi
 
 cat > /etc/cron.d/import_users << EOF


### PR DESCRIPTION
The `install.sh` script currently checks if there is a line that reads
`AuthorizedKeysCommand none` and then changes it. Old behaviour was to
simply append the line on the end of the file is this line didn't exist.

There is now a check to see if the correct line that we want already
exists, so we don't spam the end of the configuration file.